### PR TITLE
Updated with features

### DIFF
--- a/csharp/src/Bargreen.API/Bargreen.API.csproj
+++ b/csharp/src/Bargreen.API/Bargreen.API.csproj
@@ -5,6 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Interfaces\**" />
+    <Content Remove="Interfaces\**" />
+    <EmbeddedResource Remove="Interfaces\**" />
+    <None Remove="Interfaces\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="IInventoryService.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/csharp/src/Bargreen.API/Controllers/InventoryController.cs
+++ b/csharp/src/Bargreen.API/Controllers/InventoryController.cs
@@ -5,37 +5,66 @@ using System.Threading.Tasks;
 using Bargreen.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Bargreen.Services.Interfaces;
 
 namespace Bargreen.API.Controllers
 {
-    //TODO-CHALLENGE: Make the methods in this controller follow the async/await pattern
-    //TODO-CHALLENGE: Use dotnet core dependency injection to inject the InventoryService
+    //CHALLENGE: Make the methods in this controller follow the async/await pattern
+    //CHALLENGE: Use dotnet core dependency injection to inject the InventoryService
     [Route("api/[controller]")]
     [ApiController]
     public class InventoryController : ControllerBase
     {
+        IInventoryService invenService;
+
+        public InventoryController(IInventoryService isvc)
+        {
+            invenService = isvc;
+        }
+
         [Route("InventoryBalances")]
         [HttpGet]
-        public IEnumerable<InventoryBalance> GetInventoryBalances()
+        public async Task<IEnumerable<InventoryBalance>> GetInventoryBalances()
         {
-            var inventoryService = new InventoryService();
-            return inventoryService.GetInventoryBalances();
+            //var inventoryService = new InventoryService();
+            //return inventoryService.GetInventoryBalances();
+            return await Task.Run< IEnumerable < InventoryBalance >>(()=> {
+                return invenService.GetInventoryBalances();
+                });
         }
 
         [Route("AccountingBalances")]
         [HttpGet]
-        public IEnumerable<AccountingBalance> GetAccountingBalances()
+        public async Task<IEnumerable<AccountingBalance>> GetAccountingBalances()
         {
-            var inventoryService = new InventoryService();
-            return inventoryService.GetAccountingBalances();
+            //var inventoryService = new InventoryService();
+            //return inventoryService.GetAccountingBalances();
+            return await Task.Run<IEnumerable<AccountingBalance>>(() =>
+            {
+                return invenService.GetAccountingBalances();
+            });
         }
 
         [Route("InventoryReconciliation")]
         [HttpGet]
-        public IEnumerable<InventoryReconciliationResult> GetReconciliation()
+        public async Task<IEnumerable<InventoryReconciliationResult>> GetReconciliation()
         {
-            var inventoryService = new InventoryService();
-            return InventoryService.ReconcileInventoryToAccounting(inventoryService.GetInventoryBalances(), inventoryService.GetAccountingBalances());
+            //var inventoryService = new InventoryService();
+            //return InventoryService.ReconcileInventoryToAccounting(inventoryService.GetInventoryBalances(), inventoryService.GetAccountingBalances());
+            IEnumerable<InventoryBalance> invenBalance = await Task.Run<IEnumerable<InventoryBalance>>(() =>
+            {
+                return invenService.GetInventoryBalances();
+            });
+
+            IEnumerable<AccountingBalance> acctBalance = await Task.Run<IEnumerable<AccountingBalance>>(() =>
+                {
+                    return invenService.GetAccountingBalances();
+                });
+
+                return await Task.Run<IEnumerable<InventoryReconciliationResult>>(() =>
+            {
+                return invenService.ReconcileInventoryToAccounting(invenBalance, acctBalance);
+            });
         }
     }
 }

--- a/csharp/src/Bargreen.API/IInventoryService.cs
+++ b/csharp/src/Bargreen.API/IInventoryService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace Bargreen.Services.Interfaces
+{
+    interface IInventoryService
+    {
+        Task<IEnumerable<InventoryBalance>> GetInventoryBalances();
+
+        Task<IEnumerable<AccountingBalance>> GetAccountingBalances();
+
+        Task<IEnumerable<InventoryReconciliationResult>> ReconcileInventoryToAccounting(IEnumerable<InventoryBalance> inventoryBalances, IEnumerable<AccountingBalance> accountingBalances);
+    }
+}

--- a/csharp/src/Bargreen.API/Startup.cs
+++ b/csharp/src/Bargreen.API/Startup.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
+using Bargreen.Services.Interfaces;
+using Bargreen.Services;
 
 namespace Bargreen.API
 {
@@ -32,6 +34,8 @@ namespace Bargreen.API
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "Bargreen API", Version = "v1" });
             });
+
+            services.AddScoped<IInventoryService, InventoryService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/csharp/src/Bargreen.Services/Interfaces/IInventoryService.cs
+++ b/csharp/src/Bargreen.Services/Interfaces/IInventoryService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace Bargreen.Services.Interfaces
+{
+    public interface IInventoryService
+    {
+        Task<IEnumerable<InventoryBalance>> GetInventoryBalances();
+
+        Task<IEnumerable<AccountingBalance>> GetAccountingBalances();
+
+        Task<IEnumerable<InventoryReconciliationResult>> ReconcileInventoryToAccounting(IEnumerable<InventoryBalance> inventoryBalances, IEnumerable<AccountingBalance> accountingBalances);
+    }
+}

--- a/csharp/src/Bargreen.Tests/InventoryControllerTests.cs
+++ b/csharp/src/Bargreen.Tests/InventoryControllerTests.cs
@@ -6,6 +6,9 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xunit;
 
+using Bargreen.Services.Interfaces;
+using Bargreen.Services;
+
 namespace Bargreen.Tests
 {
     public class InventoryControllerTests
@@ -13,9 +16,14 @@ namespace Bargreen.Tests
         [Fact]
         public void InventoryController_Can_Return_Inventory_Balances()
         {
-            var controller = new InventoryController();
-            var result = controller.GetInventoryBalances();
-            Assert.NotEmpty(result);
+            IInventoryService svc = new InventoryService();
+            //var controller = new InventoryController();
+            var controller = new InventoryController(svc);
+            Task.Run(async () =>
+            {
+                var result = await controller.GetInventoryBalances();
+                Assert.NotEmpty(result);
+            });
         }
 
         [Fact]

--- a/csharp/src/Bargreen.Tests/InventoryServiceTests.cs
+++ b/csharp/src/Bargreen.Tests/InventoryServiceTests.cs
@@ -1,15 +1,42 @@
 using System;
 using Xunit;
+using Bargreen.Services;
+using Bargreen.Services.Interfaces;
+using Bargreen.API.Controllers;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Bargreen.Tests
 {
     public class InventoryServiceTests
     {
         [Fact]
-        public void Inventory_Reconciliation_Performs_As_Expected()
+        public async void Inventory_Reconciliation_Performs_As_Expected()
         {
-            //TODO-CHALLENGE: Verify expected output of your recon algorithm. Note, this will probably take more than one test
-            throw new NotImplementedException();
+            //CHALLENGE: Verify expected output of your recon algorithm. Note, this will probably take more than one test
+            
+            IInventoryService svc = new InventoryService();
+            var controller = new InventoryController(svc);
+
+            var discrepanciesList =(List<InventoryReconciliationResult>) await Task.Run( () =>
+            {
+                var result = controller.GetReconciliation();
+                return result;
+            });
+
+            //check results are as expected
+            Assert.Equal(3, discrepanciesList.Count);
+            Assert.True(isItemContained(discrepanciesList, "fbr77"));
+            Assert.True(isItemContained(discrepanciesList, "xxccM"));
+            Assert.True(isItemContained(discrepanciesList, "xxddM"));
+
+        }
+
+        private Boolean isItemContained(List<InventoryReconciliationResult> itemList, string itemNumber)
+        {
+            var matchCount = (from d in itemList where String.Equals(d.ItemNumber, itemNumber, StringComparison.CurrentCultureIgnoreCase) select d).Count();
+            return (matchCount > 0);
         }
     }
 }

--- a/sql/inventory_reconciliation.sql
+++ b/sql/inventory_reconciliation.sql
@@ -24,7 +24,14 @@ INSERT INTO @inventory VALUES ('xxddM', 'WLA6', 15, 747.47)
 INSERT INTO @accounting VALUES ('ABC123', 3435)
 INSERT INTO @accounting VALUES ('ZZZ99', 1930.62)
 INSERT INTO @accounting VALUES ('xxccM', 7602.75)
-INSERT INTO @accounting VALUES ('fbr77', 17.99)
+INSERT INTO @accounting VALUES ('fbr77', 17.99);
 
---TODO-CHALLENGE: Write a query to reconcile matches/differences between the inventory and accounting tables
-SELECT * FROM ...
+
+--CHALLENGE: Write a query to reconcile matches/differences between the inventory and accounting tables
+With Inven AS (
+SELECT i.ItemNumber, sum(i.PricePerItem*i.QuantityOnHand*1.0) TotalInven
+FROM @inventory i
+GROUP BY i.ItemNumber)
+SELECT * FROM Inven FULL OUTER JOIN @accounting A ON Inven.ItemNumber = A.ItemNumber
+WHERE Inven.TotalInven <> A.TotalInventoryValue
+	OR Inven.ItemNumber IS NULL OR A.ItemNumber IS NULL


### PR DESCRIPTION
In a real-world project:

 my first choice for how to handle reconciliation would be to replace the accounting table with a view that calculates values based on the inventory records, wiping out the need for reconciliation. 

Of course, sometimes normalizing the database structure is easier said than done. My second choice in a real project would be to do the comparison in SQL and pass a list of results back to the program.

In a real project, I would ask about why the Reconcile task was static, and whether it needed to be. If there were a practical requirement involved, I’m not sure the solution I used would address it. 

I would also have some questions about the best way for the InventoryReconciliationResult to report missing items in inventory or accounting. I have it showing that by a balance of 0. 


I emailed a couple questions about the InventoryReconciliation test and the static method, but Peter says the email wasn’t received. Not sure what happened to it. 

The InventoryReconciliation test has a comment that testing the output will probably require more than one test. Since the outputs of the process are hard-coded, and there isn’t anything in the challenge about modifying that, the results aren’t going to vary much. I wrote tests that validated the algorithm with the data it had, which may not have been the intent.
